### PR TITLE
Add crossplatform device discovery & serial autoconnection/disconnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To run the project and start developing or testing:
 git clone https://github.com/proveskit/proves_ground_station
 cd proves_ground_station
 yarn
-yarn dev
+yarn dev (sudo yarn dev if on linux)
 ```
 
 Ensure you have [prettier](https://prettier.io/) set up on your editor for code formatting, as CI & the Husky pre-commit hook will fail if code isn't formatted to prettier's standards.

--- a/packages/frontend/src/components/Navbar.tsx
+++ b/packages/frontend/src/components/Navbar.tsx
@@ -29,6 +29,10 @@ export default function Navbar() {
         connectionCtx.setConnection(data);
       });
 
+      socket.on("check-proves-connected", (result) => {
+        console.log(result);
+      });
+
       socket.emit("check-connected");
       socket.emit("usb-devices");
     }
@@ -37,6 +41,10 @@ export default function Navbar() {
 
   const refreshDevices = () => {
     socket?.emit("usb-devices");
+  };
+
+  const checkProvesConnected = () => {
+    socket?.emit("check-proves-connected");
   };
 
   return (
@@ -51,6 +59,12 @@ export default function Navbar() {
         </div>
         <div>
           <div className="flex gap-3 items-center">
+            <button
+              onClick={checkProvesConnected}
+              className="hover:cursor-pointer"
+            >
+              Check Proves Connected
+            </button>
             <button onClick={refreshDevices} className="hover:cursor-pointer">
               <FaSync />
             </button>

--- a/packages/frontend/src/components/Navbar.tsx
+++ b/packages/frontend/src/components/Navbar.tsx
@@ -1,5 +1,4 @@
-import { useContext, useEffect, useState } from "react";
-import { FaSync } from "react-icons/fa";
+import { useContext, useEffect } from "react";
 import { NavLink, Outlet } from "react-router";
 import { SatelliteContext } from "../context/SatelliteContext";
 import { WebsocketContext } from "../context/WebsocketContext";
@@ -12,31 +11,28 @@ const LINKS: { name: string; href: string }[] = [
 ];
 
 export default function Navbar() {
-  const [usbConnected, setUsbConnected] = useState<
-    { status: false; path: null } | { status: true; path: string }
-  >({ status: false, path: null });
-
   const socket = useContext(WebsocketContext);
   const connectionCtx = useContext(SatelliteContext)!;
 
   useEffect(() => {
     if (socket) {
-      socket.on("check-connected", (data) => {
+      socket.on("check-proves-connected", (data) => {
         connectionCtx.setConnection(data);
       });
 
-      socket.on("check-proves-connected", (result) => {
-        setUsbConnected(result);
+      socket.on("usb-connected", (data) => {
+        socket.emit("register-event-listeners");
+        connectionCtx.setConnection(data);
       });
 
-      socket.emit("check-connected");
+      socket.on("usb-disconnected", () => {
+        connectionCtx.setConnection({ connected: false });
+      });
+
+      socket.emit("check-proves-connected");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [socket]);
-
-  const checkProvesConnected = () => {
-    socket?.emit("check-proves-connected");
-  };
 
   return (
     <div>
@@ -50,38 +46,10 @@ export default function Navbar() {
         </div>
         <div>
           <div className="flex gap-3 items-center">
-            <button
-              className="hover:cursor-pointer"
-              onClick={checkProvesConnected}
-            >
-              <FaSync />
-            </button>
-            {!usbConnected.status ? (
-              <p>PROVESKit Not Connected</p>
-            ) : !connectionCtx.connection.connected ? (
-              <button
-                className="bg-white text-black px-3 py-2 rounded-md hover:cursor-pointer"
-                onClick={() => {
-                  socket?.emit("connect-device");
-                  connectionCtx.setConnection({
-                    connected: true,
-                    deviceName: usbConnected.path,
-                    connectedAt: Date.now(),
-                  });
-                }}
-              >
-                Connect
-              </button>
+            {connectionCtx.connection.connected ? (
+              <p>PROVESKit Connected</p>
             ) : (
-              <button
-                className="bg-red-500 text-white px-3 py-2 rounded-md hover:cursor-pointer"
-                onClick={() => {
-                  socket?.emit("disconnect-device");
-                  connectionCtx.setConnection({ connected: false });
-                }}
-              >
-                Disconnect
-              </button>
+              <p>Plug in PROVESKit to connect</p>
             )}
           </div>
         </div>

--- a/packages/frontend/src/context/websocket/WebsocketProvider.tsx
+++ b/packages/frontend/src/context/websocket/WebsocketProvider.tsx
@@ -5,14 +5,14 @@ import { WebsocketContext } from "./context";
 export function WebsocketProvider({ children }: { children: React.ReactNode }) {
   const [socket, setSocket] = useState<Socket | null>(null);
 
-  const connectSocket = () => {
-    setSocket(io("http://localhost:3000"));
-  };
-
   useEffect(() => {
     if (!socket) {
-      connectSocket();
+      setSocket(io("http://localhost:3000"));
     }
+
+    return () => {
+      socket?.disconnect();
+    };
   }, [socket]);
 
   return (

--- a/packages/frontend/src/routes/Home.tsx
+++ b/packages/frontend/src/routes/Home.tsx
@@ -17,6 +17,10 @@ export default function Home() {
         setMsgs((prev) => [data, ...prev]);
       });
     }
+
+    return () => {
+      socket?.off("terminal-data");
+    };
   }, [socket]);
 
   return (


### PR DESCRIPTION
Closes #1 

This PR makes the search for the ProvesKit serial port work on all platforms by searching for the [VID and PID](https://pid.codes/1209/E004/). I also made the connection/disconnection to the serial port happen automatically without needing to refresh, since needing to manually select a device isn't necessary anymore.